### PR TITLE
refactor(generateCards): function reduces to obj, hits DB only once

### DIFF
--- a/app/gameLogic/gameCreationFunctions.js
+++ b/app/gameLogic/gameCreationFunctions.js
@@ -34,15 +34,13 @@ export function generateColorsGC(whoGoesFirst, shuffleArrayFunc) {
 
 // THIS FUNCTION MAKES 25 CARDS USING OUR RANDOM WORDS AND RANDOM COLORS, AND ADDS THEM TO THE DB
 export function generateCardsGC(selectedWords, shuffledColorArray, whoGoesFirst) {
-  const gameCards = firebase.database().ref('/gameCards')
-  selectedWords.forEach((word, index) => {
-    const card = {}
-    card[index] = {
+  const gameCardObject = selectedWords.reduce((accum, word, index) => {
+    accum[index] = {
       word: word,
       clicked: false,
       color: shuffledColorArray[index]
     }
-    gameCards.update(card)
-    console.log('CREATED A CARD: ', card)
-  })
+    return accum
+  }, {})
+  firebase.database().ref('/gameCards').update(gameCardObject)
 }


### PR DESCRIPTION
generateCard function now uses reduce to create a single, 25-card object that is sent to the DB. Instead of hitting the DB once for each new card, it hits the DB only once.

close #51 