### PR TITLE
feat(users): add users to DB with current room

### DIFF
--- a/app/components/Lobby.jsx
+++ b/app/components/Lobby.jsx
@@ -27,9 +27,14 @@ export default class Lobby extends Component {
         0: auth.currentUser.uid
       }
     }
-    const newRoomRef = firebase.database().ref('/rooms').push(newRoomInstance)
+    const newRoomRef = firebase.database().ref('rooms').push(newRoomInstance)
     const newRoomKey = newRoomRef.key
-    newRoomRef.then(() => browserHistory.push(`/rooms/${newRoomKey}/wordassassins`))
+    const selectedUser = firebase.database().ref(`users/${auth.currentUser.uid}`)
+    selectedUser.set({ room: newRoomKey })
+    newRoomRef.then(() => {
+      selectedUser.set({ room: newRoomKey })
+      browserHistory.push(`/rooms/${newRoomKey}/wordassassins`)
+    })
   }
 
   // PLAYER JOINS AN EXISTING ROOM INSTANCE
@@ -41,6 +46,9 @@ export default class Lobby extends Component {
 
     const potentialPlayerRef = firebase.database().ref(`/rooms/${roomId}/potentialPlayers/`)
     const addPlayer = potentialPlayerRef.update({[playerNum]: auth.currentUser.uid})
+
+    const selectedUser = firebase.database().ref(`users/${auth.currentUser.uid}`)
+    selectedUser.set({ room: roomId })
 
     browserHistory.push(`/rooms/${roomId}/wordassassins`)
   }


### PR DESCRIPTION
When a user clicks on create new game or join a game in the lobby, they will be added to the DB in the Users Object. 
The user's current room will be set on the user as well.
close #114 
