### PR TITLE
fix(Cards): rename black gray

### DIFF
--- a/app/gameLogic/cardPickingFunctions.js
+++ b/app/gameLogic/cardPickingFunctions.js
@@ -8,7 +8,7 @@ export const updateCardsRemaining = function(cardColor, blueRemainingCards, redR
     updatedCardsRemaining = {
       blueTeamNumCardsLeft: blueRemainingCards, redTeamNumCardsLeft: redRemainingCards - 1
     }
-  } else if (cardColor === 'black') {
+  } else if (cardColor === 'gray') {
     if (activeTeam === 'redTeam') {
       updatedCardsRemaining = {
         blueTeamNumCardsLeft: 0, redTeamNumCardsLeft: redRemainingCards


### PR DESCRIPTION
Game ended incorrectly because black had not been renamed to gray. Fixed the issue in cardPickingFunction.