### PR TITLE
fix/update hint display

### DIFF
--- a/app/components/Rooms.jsx
+++ b/app/components/Rooms.jsx
@@ -49,13 +49,13 @@ export default class Rooms extends Component {
         player2: {
           playerId: activeRoom.potentialPlayers[2].userId,
           teamColor: 'blueTeam',
-          role: 'spymaster',
+          role: 'guesser',
           name: activeRoom.potentialPlayers[2].displayName
         },
         player3: {
           playerId: activeRoom.potentialPlayers[3].userId,
           teamColor: 'blueTeam',
-          role: 'guesser',
+          role: 'spymaster',
           name: activeRoom.potentialPlayers[3].displayName
         }
       }

--- a/app/components/container/ScoreboardContainer.jsx
+++ b/app/components/container/ScoreboardContainer.jsx
@@ -13,8 +13,8 @@ export default class ScoreboardContainer extends Component {
       redTeamNumCardsLeft: 8,
       blueTeamNumCardsLeft: 9,
 
-      hintToDisplay: 'blank',
-      numOfWordGuesses: 2
+      hintToDisplay: '---',
+      numOfWordGuesses: '-'
 
     }
     this.setNumCards = this.setNumCards.bind(this)

--- a/app/components/presentational/DisplayHint.jsx
+++ b/app/components/presentational/DisplayHint.jsx
@@ -12,7 +12,7 @@ const DisplayHint = props => {
   return (
     <div>
       <h3 style={{fontSize: '17'}}>Hint: <span style={styles}>{props.hintWord.toUpperCase()}</span></h3>
-      <h5 style={{fontSize: '17'}}>Cards Associated with Hint: {props.hintNumGuessesAllowed - 1}</h5>
+      <h5 style={{fontSize: '17'}}>Cards Associated with Hint: {(props.hintNumGuessesAllowed - 1 > 0) ? props.hintNumGuessesAllowed - 1 : 0}</h5>
       <h5 style={{fontSize: '17'}}>Guesses Remaining: {props.hintNumGuessesAllowed}</h5>
     </div>
   )

--- a/app/components/presentational/InactiveSpymasterHinter.jsx
+++ b/app/components/presentational/InactiveSpymasterHinter.jsx
@@ -10,7 +10,7 @@ const InactiveSpymasterHinter = props => {
         !props.possibleHint?<h3>Waiting for Spymaster to Submit A Hint</h3>:
         <div>
           <h3>The word to use as a hint is {props.possibleHint} </h3>
-          <h3>The number of guesses allowed is {props.numberOfWordsToGuess} </h3>
+          <h3>The number of words associated is {props.numberOfWordsToGuess - 1} </h3>
           <Button onClick={props.validateHint}>Validate</Button>
           <Button>Resubmit Hint</Button>
         </div>


### PR DESCRIPTION
Updated hint display so that words associated never goes before 0. And at beginning of round it shows --- for the hint word and - for number of guesses.

close #154 
close #155 
