### PR TITLE
Feat/round win view

### DIFF
--- a/app/components/Rooms.jsx
+++ b/app/components/Rooms.jsx
@@ -30,7 +30,8 @@ export default class Rooms extends Component {
         roundActive: false,
         whoGoesFirst: 'blueTeam',
         activeTeam: 'blueTeam',
-        activeRole: 'spymaster'
+        activeRole: 'spymaster',
+        roundWinner: 'none'
       },
 
       players: {

--- a/app/components/container/BoardContainer.jsx
+++ b/app/components/container/BoardContainer.jsx
@@ -135,7 +135,6 @@ export default class BoardContainer extends Component {
   }
 
   render() {
-    console.log('the props for cards remaining', this.props.currentGameStatus.cardsRemaining.blueTeamNumCardsLeft)
     return (
       <div >
         {

--- a/app/components/container/BoardContainer.jsx
+++ b/app/components/container/BoardContainer.jsx
@@ -152,7 +152,7 @@ export default class BoardContainer extends Component {
               teamColor={this.state.teamColor}
             /> :
 
-              this.props.currentGameStatus.roundWinner !== 'none' ? <div><h1>Yay, {this.props.currentGameStatus.roundWinner} won the round!</h1>
+              this.props.currentGameStatus.roundWinner !== 'none' ? <div style={{textAlign: 'center'}}><h1 style={{backgroundColor: this.props.currentGameStatus.roundWinner.slice(0, -4)}}>All assassins have been found: {this.props.currentGameStatus.roundWinner.slice(0, -4).toUpperCase()} TEAM won the round!</h1>
               <Button onClick={this.startNewRoundOnClick}>Start Round</Button></div> :
               <Button onClick={this.startNewRoundOnClick}>Start Round</Button>
         }

--- a/app/components/container/BoardContainer.jsx
+++ b/app/components/container/BoardContainer.jsx
@@ -152,7 +152,7 @@ export default class BoardContainer extends Component {
               teamColor={this.state.teamColor}
             /> :
 
-              this.props.currentGameStatus.roundWinner !== 'none' ? <div style={{textAlign: 'center'}}><h1 style={{backgroundColor: this.props.currentGameStatus.roundWinner.slice(0, -4)}}>All assassins have been found: {this.props.currentGameStatus.roundWinner.slice(0, -4).toUpperCase()} TEAM won the round!</h1>
+              this.props.currentGameStatus.roundWinner !== 'none' ? <div style={{textAlign: 'center'}}><h1 style={{backgroundColor: this.props.currentGameStatus.roundWinner.slice(0, -4), fontSize: '80'}}>All assassins have been found: {this.props.currentGameStatus.roundWinner.slice(0, -4).toUpperCase()} TEAM won the round!</h1>
               <Button onClick={this.startNewRoundOnClick}>Start Round</Button></div> :
               <Button onClick={this.startNewRoundOnClick}>Start Round</Button>
         }

--- a/app/components/container/BoardContainer.jsx
+++ b/app/components/container/BoardContainer.jsx
@@ -12,7 +12,8 @@ export default class BoardContainer extends Component {
       activeTeam: '',
       numOfWordGuesses: 0,
       role: '',
-      teamColor: ''
+      teamColor: '',
+      cardsRemaining: {}
     }
     this.pickCard = this.pickCard.bind(this)
     this.startNewRoundOnClick = this.startNewRoundOnClick.bind(this)
@@ -30,6 +31,7 @@ export default class BoardContainer extends Component {
 
       this.setState({ activeTeam: currentGameStatus.activeTeam })
       this.setState({ numOfWordGuesses: currentGameStatus.displayHint.numOfWordGuesses })
+      this.setState({ cardsRemaining: currentGameStatus.cardsRemaining })
     })
 
     const getCardsForState = firebase.database().ref(`gameInstances/${this.props.gameId}/gameCards`)
@@ -59,6 +61,7 @@ export default class BoardContainer extends Component {
     const clickedCardIndex = data.children.props.value
     const clickedCard = firebase.database().ref(`gameInstances/${this.props.gameId}/gameCards/${clickedCardIndex}`)
     clickedCard.update({ clicked: true })
+
 
     const dataRef = firebase.database().ref()
 
@@ -132,6 +135,7 @@ export default class BoardContainer extends Component {
   }
 
   render() {
+    console.log('the props for cards remaining', this.props.currentGameStatus.cardsRemaining.blueTeamNumCardsLeft)
     return (
       <div >
         {

--- a/app/components/container/BoardContainer.jsx
+++ b/app/components/container/BoardContainer.jsx
@@ -151,7 +151,10 @@ export default class BoardContainer extends Component {
               role={this.state.role}
               teamColor={this.state.teamColor}
             /> :
-            <Button onClick={this.startNewRoundOnClick}>Start Round</Button>
+
+              this.props.currentGameStatus.roundWinner !== 'none' ? <div><h1>Yay, {this.props.currentGameStatus.roundWinner} won the round!</h1>
+              <Button onClick={this.startNewRoundOnClick}>Start Round</Button></div> :
+              <Button onClick={this.startNewRoundOnClick}>Start Round</Button>
         }
       </div >
     )

--- a/app/gameLogic/roundManagementFunctions.js
+++ b/app/gameLogic/roundManagementFunctions.js
@@ -6,14 +6,16 @@ export const updateRoundsWon = function(blueCardsLeft, redCardsLeft, blueRoundsW
       RoundsWonByTeams: {
         blueTeamNumRoundsWon: blueRoundsWon + 1,
         redTeamNumRoundsWon: redRoundsWon
-      }
+      },
+      roundWinner: 'blueTeam'
     }
   } else if (redCardsLeft === 0) {
     currPhaseOfGame = {
       RoundsWonByTeams: {
         blueTeamNumRoundsWon: blueRoundsWon,
         redTeamNumRoundsWon: redRoundsWon + 1
-      }
+      },
+      roundWinner: 'redTeam'
     }
   }
   return currPhaseOfGame


### PR DESCRIPTION
After a team wins a round, the board is replaced by a notification that the proper team has won that round. The button for a new round is still available and rerenders the board when clicked.
close #170 