### PR TITLE
feat(rules): implement rules modal

### DIFF
--- a/app/components/GameView.jsx
+++ b/app/components/GameView.jsx
@@ -5,6 +5,7 @@ import Scoreboard from './container/ScoreboardContainer.jsx'
 import ActiveSpyMasterHinterContainer from './container/ActiveSpyMasterHinterContainer'
 import InactiveSpyMasterHinterContainer from './container/InactiveSpymasterHinterContainer'
 import GameStatusContainer from './container/GameStatusContainer'
+import RulesModal from './presentational/RulesModal'
 
 import { Container, Grid } from 'semantic-ui-react'
 
@@ -46,8 +47,18 @@ export default class GameView extends Component {
   render() {
     return (
       <div>
-        <h1 className="title">Word Assassins</h1>
-
+        <Grid columns="three">
+          <Grid.Row style={{height: '75'}}>
+            <Grid.Column>
+            </Grid.Column>
+            <Grid.Column>
+              <h1 style={{marginTop: '10'}}className="title">Word Assassins</h1>
+            </Grid.Column>
+            <Grid.Column style={{marginTop: '10'}}>
+              <RulesModal />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
         {
           Object.keys(this.state).length >= 6 &&
             <div>
@@ -55,21 +66,21 @@ export default class GameView extends Component {
                 <Grid.Row>
                   <Grid.Column width={9}>
                     <div>
-                    <Scoreboard
-                      gameId={this.props.params.gameId}
-                      currentGameStatus={this.state.currentGameStatus}
-                      players={this.state.players}
-                    />
+                      <Scoreboard
+                        gameId={this.props.params.gameId}
+                        currentGameStatus={this.state.currentGameStatus}
+                        players={this.state.players}
+                      />
                     </div>
                   </Grid.Column>
 
                   <Grid.Column width={7}>
                     <div>
-                  <GameStatusContainer
-                      currentGameStatus={this.state.currentGameStatus}
-                      players={this.state.players}
-                    />
-                      </div>
+                      <GameStatusContainer
+                          currentGameStatus={this.state.currentGameStatus}
+                          players={this.state.players}
+                      />
+                    </div>
                   </Grid.Column>
                 </Grid.Row>
               </Grid>

--- a/app/components/Rooms.jsx
+++ b/app/components/Rooms.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import firebase from 'APP/fire'
 import { browserHistory } from 'react-router'
 import { Container, Header, Table, Button, Segment } from 'semantic-ui-react'
+import RulesModal from './presentational/RulesModal'
 
 export default class Rooms extends Component {
   constructor(props) {
@@ -80,6 +81,7 @@ export default class Rooms extends Component {
               <Header as='h2'>Game Room</Header>
               <p style={{paddingBottom: '10px'}}>Once you have four players in a room, you will be able to start a new game.
                                         Enjoy!</p>
+              <RulesModal />
               <Button centered positive style={{color: 'black', backgroundColor: 'white'}} disabled={(activeRoom && activeRoom.potentialPlayers.length < 4) || (activeRoom && activeRoom.potentialPlayers.length > 4)}
               onClick={(event) => this.onClickNewGame(event, activeRoom)}>
               Start New Game

--- a/app/components/presentational/RulesModal.jsx
+++ b/app/components/presentational/RulesModal.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Button, Header, Icon, Image, Modal } from 'semantic-ui-react'
+
+const RulesModal = () =>
+  (<Modal trigger={<Button style={{backgroundColor: '#EDC832'}}>Instructions</Button>} closeIcon>
+    <Modal.Header></Modal.Header>
+    <Modal.Content image scrolling>
+
+      {/* ~~UCOMMENT TO ADD AN IMAGE TO THE MODAL~~
+        <Image
+          size='medium'
+          src='/assets/images/wireframe/image.png'
+          wrapped
+      /> */}
+
+      <Modal.Description>
+        <Header style={{fontSize: '25'}}>Word Assassins Instructions for General Play</Header>
+        <p>Word Assassins is played by two teams of two players, the Red team and Blue team.</p>
+
+        <p>In the game screen all four players can see a grid of 25 words <br></br> On each team one player is the Spymaster and their teammate is the Guesser.</p>
+
+        <p>The goal of the game is to have your team’s Guesser reveal all of your team’s cards before <br></br>the the other team reveal’s theirs. Each team’s turn consists of two phases:</p>
+
+        <p style={{textDecoration: 'underline', fontWeight: 'bold'}}>Phase 1 - Submitting the Hint</p>
+        <p>The two Spymasters are able to see which words are associated with which color, the guessers are not.</p>
+        <p> When it is the Blue team’s turn, the Blue teams Spymaster looks at the board and enters a one word hint <br></br>and the number of Blue words that they want the Blue Guesser to click based on that hint. <br></br>(proper nouns like “New York” can be multiple words)</p>
+
+        <p>An example hint might be: "CAKE, 3" With the goal of trying to get their teammate to select <br></br>the words "DESSERT", "CHOCOLATE", and "SWEET".</p>
+
+        <p>After a hint and number are entered by the Blue Spymaster, the Red team’s Spymaster then reviews <br></br>the hint to make sure it is legal and either confirms it or requests a change. <br></br>Once confirmed the Blue Spymaster submits the hint and the next phase begins.</p>
+
+        <p style={{textDecoration: 'underline', fontWeight: 'bold'}}>Phase 2 - Guessing</p>
+        <p>All players can now see the hint word, the number of words the spymaster says are associated, <br></br>and the number of remaining guesses the Blue Guesser has.</p>
+
+        <p>The Blue Guesser now has to decide which words on the board their teammate is hinting at. Once the guesser decides <br></br>on a word to guess, they click a card, the color of the card is revealed, and the word is hidden. Now one of 4 things happen:</p>
+
+        <p>If the card selected is Blue, the number of Blue cards remaining to win the round decreases by one. If there are still guesses <br></br>remaining, the Guesser can keep guessing or click the pass button to end their turn.</p>
+
+        <p>If the card is Red, the number of Red cards remaining to win the round decreases by one. Then the Blue team’s turn ends and <br></br>the Red team Spymaster gets to set a hint, starting the process over again.</p>
+
+        <p>If the card is white, then neither Red or Blue cards remaining decrease and the Blue team’s turn ends. The Red team Spymaster <br></br>gets to set a hint, starting the process over again.</p>
+
+        <p>If the card is the lone gray assassin card, then the entire round ends and the team that clicked it loses the round.</p>
+      </Modal.Description>
+    </Modal.Content>
+    {/* <Modal.Actions>
+      <Button primary> ~~ Uncomment to institute button, but button needs link
+        Proceed <Icon name='right chevron' />
+      </Button>}
+    </Modal.Actions> */}
+  </Modal>)
+
+export default RulesModal


### PR DESCRIPTION
close #135 

A general rules modal is available by clicking the 'Instructions' button in the Rooms view and also on the main game board. The rules can be tucked back away either by clicking the close 'X' or by clicking outside of them.

Still need a broader rules sheet and eventually some point of access hover rules.